### PR TITLE
Skip events that we failed to process

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuberik/github-screener
 
-go 1.13
+go 1.15
 
 require (
 	github.com/go-logr/logr v0.1.0

--- a/operators/github.go
+++ b/operators/github.go
@@ -100,7 +100,7 @@ func (p *EventPoller) PollOnce() (*EventPollResult, error) {
 		e, err := p.Collect(events[i], payload)
 		if err != nil {
 			p.log.Error(err, "failed to process event", "id", *events[i].ID)
-			break
+			continue
 		} else if e != nil {
 			collectedEvents = append(collectedEvents, *e)
 			p.checkpoint = *events[i].ID


### PR DESCRIPTION
This might also cause skipping events on transient errors, but current implementation blocks further screening on non-transient errors.